### PR TITLE
Allow user to set julia bin via `JULIA_LSP_JULIA_BIN` environment variable

### DIFF
--- a/bin/julia-lsp
+++ b/bin/julia-lsp
@@ -36,5 +36,7 @@ export DETACHED="--detached=no"
 
 export JULIA_LOAD_PATH=":"
 export JULIA_DEPOT_PATH="${PKG_ROOT}/store/lsdepot/v1"
+export JULIAUP_CHANNEL="release"
 
-exec julia --startup-file=no --history-file=no --depwarn=no "${PKG_ROOT}/extension/scripts/languageserver/main.jl" "$JULIA_ENVIRONMENT_PATH" "$DEBUG" "$IGNORE_TELEMETRY_CRASH" "$OLD_DEPOT_PATH" "$STORAGE_PATH" "$USE_SYMSERVER_DOWNLOADS" "$SYMSERVER_UPSTREAM" "$DETACHED"
+: ${JULIA_LSP_JULIA_BIN:=julia}
+exec $JULIA_LSP_JULIA_BIN --startup-file=no --history-file=no --depwarn=no "${PKG_ROOT}/extension/scripts/languageserver/main.jl" "$JULIA_ENVIRONMENT_PATH" "$DEBUG" "$IGNORE_TELEMETRY_CRASH" "$OLD_DEPOT_PATH" "$STORAGE_PATH" "$USE_SYMSERVER_DOWNLOADS" "$SYMSERVER_UPSTREAM" "$DETACHED"

--- a/bin/julia-lsp
+++ b/bin/julia-lsp
@@ -36,7 +36,6 @@ export DETACHED="--detached=no"
 
 export JULIA_LOAD_PATH=":"
 export JULIA_DEPOT_PATH="${PKG_ROOT}/store/lsdepot/v1"
-export JULIAUP_CHANNEL="release"
 
 : ${JULIA_LSP_JULIA_BIN:=julia}
-exec $JULIA_LSP_JULIA_BIN --startup-file=no --history-file=no --depwarn=no "${PKG_ROOT}/extension/scripts/languageserver/main.jl" "$JULIA_ENVIRONMENT_PATH" "$DEBUG" "$IGNORE_TELEMETRY_CRASH" "$OLD_DEPOT_PATH" "$STORAGE_PATH" "$USE_SYMSERVER_DOWNLOADS" "$SYMSERVER_UPSTREAM" "$DETACHED"
+exec "$JULIA_LSP_JULIA_BIN" --startup-file=no --history-file=no --depwarn=no "${PKG_ROOT}/extension/scripts/languageserver/main.jl" "$JULIA_ENVIRONMENT_PATH" "$DEBUG" "$IGNORE_TELEMETRY_CRASH" "$OLD_DEPOT_PATH" "$STORAGE_PATH" "$USE_SYMSERVER_DOWNLOADS" "$SYMSERVER_UPSTREAM" "$DETACHED"

--- a/bin/julia-lsp.cmd
+++ b/bin/julia-lsp.cmd
@@ -22,9 +22,12 @@ IF "%SYMBOL_SERVER%"=="" (
 ) ELSE (
     set "SYMSERVER_UPSTREAM=%SYMBOL_SERVER%"
 )
-set "DETACHED=--detached=no"
+IF "%JULIA_LSP_JULIA_BIN%"=="" (
+    set "JULIA_LSP_JULIA_BIN=julia"
+)
 
+set "DETACHED=--detached=no"
 set "JULIA_LOAD_PATH=;"
 set "JULIA_DEPOT_PATH=%PKG_ROOT%\store\lsdepot\v1"
 
-julia --startup-file=no --history-file=no --depwarn=no "%PKG_ROOT%\extension\scripts\languageserver\main.jl" "%JULIA_ENVIRONMENT_PATH%" "%DEBUG%" "%IGNORE_TELEMETRY_CRASH%" "%OLD_DEPOT_PATH%" "%STORAGE_PATH%" "%USE_SYMSERVER_DOWNLOADS%" "%SYMSERVER_UPSTREAM%" "%DETACHED%"
+"%JULIA_LSP_JULIA_BIN%" --startup-file=no --history-file=no --depwarn=no "%PKG_ROOT%\extension\scripts\languageserver\main.jl" "%JULIA_ENVIRONMENT_PATH%" "%DEBUG%" "%IGNORE_TELEMETRY_CRASH%" "%OLD_DEPOT_PATH%" "%STORAGE_PATH%" "%USE_SYMSERVER_DOWNLOADS%" "%SYMSERVER_UPSTREAM%" "%DETACHED%"


### PR DESCRIPTION
Currently, `julia-lsp` uses what ever binary the `julia` command points to. However, this command may point to a julia version for which `julia-lsp` does not run reliably (say, the current alpha version). Instead, it is more desirable to run `julia-lsp` always on a "stable" julia version that is not necessarily the same as the julia version required by the developed project.

To address this issue, this PR introduces an environment variable `JULIA_LSP_JULIA_BIN` which the user can set to a preferred julia binary. If this variable is unset, we default to the original behavior of calling `julia` directly.

A few remarks

1. I do not have access to a windows machine to test the cmd script. Hence, that part is untested.
2. I am not sure about the variable name for this option. Happy to have it changed to something else if preferred.