### PR TITLE
chore(workflows): checkout with bot token

### DIFF
--- a/.github/workflows/keepalive.yaml
+++ b/.github/workflows/keepalive.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_GH_TOKEN }}
       - uses: gautamkrishnar/keepalive-workflow@v1
         with:
           gh_token: ${{ secrets.BOT_GH_TOKEN }}


### PR DESCRIPTION
This might fix permission issues with the keepalive workflow.
