### PR TITLE
Add the (now required) SSI exe and version arguments to the LanguageServer

### DIFF
--- a/bin/julia-lsp
+++ b/bin/julia-lsp
@@ -38,4 +38,7 @@ export JULIA_LOAD_PATH=":"
 export JULIA_DEPOT_PATH="${PKG_ROOT}/store/lsdepot/v1"
 
 : ${JULIA_LSP_JULIA_BIN:=julia}
-exec "$JULIA_LSP_JULIA_BIN" --startup-file=no --history-file=no --depwarn=no "${PKG_ROOT}/extension/scripts/languageserver/main.jl" "$JULIA_ENVIRONMENT_PATH" "$DEBUG" "$IGNORE_TELEMETRY_CRASH" "$OLD_DEPOT_PATH" "$STORAGE_PATH" "$USE_SYMSERVER_DOWNLOADS" "$SYMSERVER_UPSTREAM" "$DETACHED"
+export JULIA_SSI_EXE="$JULIA_LSP_JULIA_BIN"
+export JULIA_SSI_VERSION="$(exec ${JULIA_SSI_EXE} --version | awk '{print $3}')"
+
+exec "$JULIA_LSP_JULIA_BIN" --startup-file=no --history-file=no --depwarn=no "${PKG_ROOT}/extension/scripts/languageserver/main.jl" "$JULIA_ENVIRONMENT_PATH" "$DEBUG" "$IGNORE_TELEMETRY_CRASH" "$OLD_DEPOT_PATH" "$STORAGE_PATH" "$USE_SYMSERVER_DOWNLOADS" "$SYMSERVER_UPSTREAM" "$DETACHED" "$JULIA_SSI_EXE" "$JULIA_SSI_VERSION"

--- a/bin/julia-lsp.cmd
+++ b/bin/julia-lsp.cmd
@@ -26,8 +26,13 @@ IF "%JULIA_LSP_JULIA_BIN%"=="" (
     set "JULIA_LSP_JULIA_BIN=julia"
 )
 
+set "JULIA_SSI_EXE=%JULIA_LSP_JULIA_BIN%"
+for /f "tokens=3" %%v in ('%JULIA_SSI_EXE% --version') do (
+    set JULIA_SSI_VERSION=%%v
+)
+
 set "DETACHED=--detached=no"
 set "JULIA_LOAD_PATH=;"
 set "JULIA_DEPOT_PATH=%PKG_ROOT%\store\lsdepot\v1"
 
-"%JULIA_LSP_JULIA_BIN%" --startup-file=no --history-file=no --depwarn=no "%PKG_ROOT%\extension\scripts\languageserver\main.jl" "%JULIA_ENVIRONMENT_PATH%" "%DEBUG%" "%IGNORE_TELEMETRY_CRASH%" "%OLD_DEPOT_PATH%" "%STORAGE_PATH%" "%USE_SYMSERVER_DOWNLOADS%" "%SYMSERVER_UPSTREAM%" "%DETACHED%"
+"%JULIA_LSP_JULIA_BIN%" --startup-file=no --history-file=no --depwarn=no "%PKG_ROOT%\extension\scripts\languageserver\main.jl" "%JULIA_ENVIRONMENT_PATH%" "%DEBUG%" "%IGNORE_TELEMETRY_CRASH%" "%OLD_DEPOT_PATH%" "%STORAGE_PATH%" "%USE_SYMSERVER_DOWNLOADS%" "%SYMSERVER_UPSTREAM%" "%DETACHED%" "%JULIA_SSI_EXE%" "%JULIA_SSI_VERSION%"


### PR DESCRIPTION
The Julia language server now requires [10 arguments](https://github.com/julia-vscode/julia-vscode/blob/main/scripts/languageserver/main.jl), with the last two being the [Julia exe and version number used to run the SSI on](https://github.com/julia-vscode/SymbolServer.jl/blob/2201c26a43013a7bf71b4829ee4967e072070cab/src/SymbolServer.jl). 

This PR is a quick fix which just uses the same Julia binary.
It looks like this is the default for the Symbol Server, so hopefully it is not an issue.

This fix gets the server back up and running on my machine.

Cheers!